### PR TITLE
Fixed missing class for bootstrap temlplate

### DIFF
--- a/src/IPub/ConfirmationDialog/Components/template/bootstrap.latte
+++ b/src/IPub/ConfirmationDialog/Components/template/bootstrap.latte
@@ -1,5 +1,5 @@
 <div n:class="confirmation-dialog, modal, fade, display, $class ? $class" tabindex="-1" role="dialog">
-	<form n:name="form" n:class="form-horizontal, $useAjax ? ajax" data-ajax-off="['history','scrollTo']">
+	<form n:name="form" n:class="modal-dialog, form-horizontal, $useAjax ? ajax" data-ajax-off="['history','scrollTo']">
 		<div class="modal-content">
 			<div class="modal-header">
 				<button n:name="no" class="close" data-dismiss="modal" data-ajax-off="['history','scrollTo']">&times;</button>


### PR DESCRIPTION
Bootstrap modals need to be wrapped in `.modal-dialog` class, which was missing here.